### PR TITLE
chore: remove "alpha" status

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-<h1 align="center"/>Elk <sup><em>alpha</em></sup></h1>
+<h1 align="center"/>Elk</h1>
 
 <p align="center">
 A nimble Mastodon web client

--- a/profile/README.md
+++ b/profile/README.md
@@ -13,9 +13,5 @@ A nimble Mastodon web client
 <br/>
 
 <p align="center">
-Elk isn't ready for wide adoption yet. We recommend you to use it if you would like to help us building it.
-</p>
-
-<p align="center">
 To get involved, join the <a href="https://chat.elk.zone">Elk discord server</a> and chat with us to learn more about the project.
 </p>


### PR DESCRIPTION
Elk is removing alpha status, preparing v1.0.0 release. It looks like I don't have write permission for this repository.